### PR TITLE
Specify KMS key to enable Server-Side Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | allowed\_aws\_services\_for\_sns\_published | AWS services that will have permission to publish to SNS topic. Used when no external json policy is used. | `list(string)` | <pre>[<br>  "cloudwatch.amazonaws.com"<br>]</pre> | no |
 | attributes | Additional attributes to distinguish this SNS topic | `list(string)` | `[]` | no |
+| kms\_master\_key\_id | The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK | `string` | `null` | no |
 | name | Name to distinguish this SNS topic | `string` | `"sns"` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | n/a | yes |
 | sns\_topic\_policy\_json | The fully-formed AWS policy as JSON | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 |------|-------------|------|---------|:--------:|
 | allowed\_aws\_services\_for\_sns\_published | AWS services that will have permission to publish to SNS topic. Used when no external json policy is used. | `list(string)` | <pre>[<br>  "cloudwatch.amazonaws.com"<br>]</pre> | no |
 | attributes | Additional attributes to distinguish this SNS topic | `list(string)` | `[]` | no |
+| kms\_master\_key\_id | The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK | `string` | `null` | no |
 | name | Name to distinguish this SNS topic | `string` | `"sns"` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | `string` | n/a | yes |
 | sns\_topic\_policy\_json | The fully-formed AWS policy as JSON | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,9 @@ module "label" {
 }
 
 resource "aws_sns_topic" "this" {
-  name         = module.label.id
-  display_name = module.label.id
+  name              = module.label.id
+  display_name      = module.label.id
+  kms_master_key_id = var.kms_master_key_id
 }
 
 resource "aws_sns_topic_subscription" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "allowed_aws_services_for_sns_published" {
   default     = ["cloudwatch.amazonaws.com"]
 }
 
+variable "kms_master_key_id" {
+  type        = string
+  description = "The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK"
+  default     = null
+}
+
 variable "sns_topic_policy_json" {
   type        = string
   description = "The fully-formed AWS policy as JSON"


### PR DESCRIPTION
## what
* A variable has been added to allow users to specify a KMS key ARN for Server-Side Encryption
* This variable defaults to `null` making it optional

## why
* A common use case for SNS messages is processing sensitive data (ex: PII, PHI, payment card)
* Many vendors and government regulators will require end-to-end encryption of this sensitive data

## references
* Resolves #7 