### PR TITLE
Add toggle for KMS encryption

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,11 @@ data "aws_caller_identity" "current" {}
 resource "aws_sns_topic" "this" {
   name              = module.this.id
   display_name      = module.this.id
-  kms_master_key_id = var.kms_master_key_id
+  kms_master_key_id = var.kms_encryption_enabled ? var.kms_master_key_id : ""
   delivery_policy   = var.delivery_policy
   tags              = module.this.tags
 }
+
 
 resource "aws_sns_topic_subscription" "this" {
   for_each = var.subscribers

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,10 @@ variable "delivery_policy" {
   description = "The SNS delivery policy as JSON."
   default     = null
 }
+
+variable "kms_encryption_enabled" {
+  type        = bool
+  description = "To enable SNS topic encryption"
+  default     = true
+}
+


### PR DESCRIPTION
## what
* add toggle for KMS  encryption for SNS topic

## why
* Default is to encrypt with AWS managed CMK, this breaks the GuardDuty module as it doesn't have permissions to decrypt the AWS SNS CMK

## references
* https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying.html
* https://github.com/cloudposse/terraform-aws-guardduty/issues/10
