### PR TITLE
Disable policy if no principals

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,8 +8,8 @@ module "sns" {
   allowed_aws_services_for_sns_published = var.allowed_aws_services_for_sns_published
 
   sqs_dlq_enabled    = false
-  fifo_topic         = true
-  fifo_queue_enabled = true
+  fifo_topic         = false
+  fifo_queue_enabled = false
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,11 +5,11 @@ provider "aws" {
 module "sns" {
   source = "../../"
 
-  # allowed_aws_services_for_sns_published = var.allowed_aws_services_for_sns_published
+  allowed_aws_services_for_sns_published = var.allowed_aws_services_for_sns_published
 
-  sqs_dlq_enabled    = false
-  fifo_topic         = false
-  fifo_queue_enabled = false
+  sqs_dlq_enabled    = true
+  fifo_topic         = true
+  fifo_queue_enabled = true
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,7 +7,7 @@ module "sns" {
 
   allowed_aws_services_for_sns_published = var.allowed_aws_services_for_sns_published
 
-  sqs_dlq_enabled    = true
+  sqs_dlq_enabled    = false
   fifo_topic         = true
   fifo_queue_enabled = true
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 module "sns" {
   source = "../../"
 
-  allowed_aws_services_for_sns_published = var.allowed_aws_services_for_sns_published
+  # allowed_aws_services_for_sns_published = var.allowed_aws_services_for_sns_published
 
   sqs_dlq_enabled    = false
   fifo_topic         = false

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,8 @@ locals {
   sqs_queue_name = var.fifo_queue_enabled ? "${module.this.id}.fifo" : module.this.id
 
   sqs_dlq_enabled = local.enabled && var.sqs_dlq_enabled
+
+  sns_queue_policy_enabled = local.enabled && length(var.allowed_aws_services_for_sns_published) > 0 || length(var.allowed_iam_arns_for_sns_publish) > 0
 }
 
 resource "aws_sns_topic" "this" {
@@ -39,14 +41,14 @@ resource "aws_sns_topic_subscription" "this" {
 }
 
 resource "aws_sns_topic_policy" "this" {
-  count = local.enabled ? 1 : 0
+  count = local.sns_queue_policy_enabled ? 1 : 0
 
   arn    = join("", aws_sns_topic.this.*.arn)
   policy = length(var.sns_topic_policy_json) > 0 ? var.sns_topic_policy_json : join("", data.aws_iam_policy_document.aws_sns_topic_policy.*.json)
 }
 
 data "aws_iam_policy_document" "aws_sns_topic_policy" {
-  count = local.enabled ? 1 : 0
+  count = local.sns_queue_policy_enabled ? 1 : 0
 
   policy_id = "SNSTopicsPub"
   statement {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
 
   sqs_dlq_enabled = local.enabled && var.sqs_dlq_enabled
 
-  sns_queue_policy_enabled = local.enabled && length(var.allowed_aws_services_for_sns_published) > 0 || length(var.allowed_iam_arns_for_sns_publish) > 0
+  sns_topic_policy_enabled = local.enabled && length(var.allowed_aws_services_for_sns_published) > 0 || length(var.allowed_iam_arns_for_sns_publish) > 0
 }
 
 resource "aws_sns_topic" "this" {
@@ -41,14 +41,14 @@ resource "aws_sns_topic_subscription" "this" {
 }
 
 resource "aws_sns_topic_policy" "this" {
-  count = local.sns_queue_policy_enabled ? 1 : 0
+  count = local.sns_topic_policy_enabled ? 1 : 0
 
   arn    = join("", aws_sns_topic.this.*.arn)
   policy = length(var.sns_topic_policy_json) > 0 ? var.sns_topic_policy_json : join("", data.aws_iam_policy_document.aws_sns_topic_policy.*.json)
 }
 
 data "aws_iam_policy_document" "aws_sns_topic_policy" {
-  count = local.sns_queue_policy_enabled ? 1 : 0
+  count = local.sns_topic_policy_enabled ? 1 : 0
 
   policy_id = "SNSTopicsPub"
   statement {


### PR DESCRIPTION
## what
* Disable policy if no principals 

## why
* Prevent a malformed policy

## references
* https://github.com/cloudposse/actions/runs/4267827651?check_suite_focus=true
* Fixes https://github.com/cloudposse/terraform-aws-code-deploy/pull/10
* Supersedes and closes https://github.com/cloudposse/terraform-aws-sns-topic/pull/41#issue-1043067068

```
  on .terraform/modules/code_deploy_blue_green.sns_topic/main.tf line 41, in resource "aws_sns_topic_policy" "this":
  41: resource "aws_sns_topic_policy" "this" {

}
    apply.go:15: 
        	Error Trace:	apply.go:15
        	            				examples_complete_test.go:37
        	Error:      	Received unexpected error:
        	            	FatalError{Underlying: error while running command: exit status 1; 
        	            	Error: InvalidParameter: Invalid parameter: Policy Error: null
        	            		status code: 400, request id: 80029a7c-8d1d-5945-a2e0-c06d7d34cecc
        	            	
        	            	  on .terraform/modules/code_deploy_blue_green.sns_topic/main.tf line 41, in resource "aws_sns_topic_policy" "this":
        	            	  41: resource "aws_sns_topic_policy" "this" {
        	            	
        	            	}
        	Test:       	TestExamplesComplete
```

