### PR TITLE
remove notice about redrive_policy from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ This module provides:
 - SNS topic subscriptions
 
 It's possible to subscribe SQS as Dead Letter Queue.
-**Unfortunately** `redrive_policy` is not yet available in `terraform`. It's waiting for PR https://github.com/terraform-providers/terraform-provider-aws/pull/11770
-Without `redrive_policy` it's impossible to configure DLQ.
 
 
 ## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)

--- a/README.yaml
+++ b/README.yaml
@@ -48,8 +48,6 @@ introduction: |-
   - SNS topic subscriptions
 
   It's possible to subscribe SQS as Dead Letter Queue.
-  **Unfortunately** `redrive_policy` is not yet available in `terraform`. It's waiting for PR https://github.com/terraform-providers/terraform-provider-aws/pull/11770
-  Without `redrive_policy` it's impossible to configure DLQ.
 
 usage: |-
   Amazon Simple Notification Service (Amazon SNS) is a web service that coordinates and manages the delivery or sending of messages to subscribing endpoints or clients.


### PR DESCRIPTION
## what
redrive_plicy was added in e932f7e ( tag:v0.20.0 ), but this notice was missed to be removed.

## why
the notice could be misleading to users who visit the module's readme and see the notice even though the feature already exists in the module.

## references
- https://github.com/terraform-providers/terraform-provider-aws/pull/11770
- e932f7e ( tag:v0.20.0 )
