### PR TITLE
Added filter_policy and filter_policy_scope functionality to subscribers

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,8 @@ resource "aws_sns_topic_subscription" "this" {
   protocol               = var.subscribers[each.key].protocol
   endpoint               = var.subscribers[each.key].endpoint
   endpoint_auto_confirms = var.subscribers[each.key].endpoint_auto_confirms
+  filter_policy          = var.subscribers[each.key].filter_policy
+  filter_policy_scope    = var.subscribers[each.key].filter_policy_scope
   raw_message_delivery   = var.subscribers[each.key].raw_message_delivery
   redrive_policy = var.sqs_dlq_enabled ? coalesce(var.redrive_policy, jsonencode({
     deadLetterTargetArn = join("", aws_sqs_queue.dead_letter_queue.*.arn)

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_sns_topic" "this" {
 resource "aws_sns_topic_subscription" "this" {
   for_each = local.enabled ? var.subscribers : {}
 
-  topic_arn              = join("", aws_sns_topic.this.*.arn)
+  topic_arn              = join("", aws_sns_topic.this[*].arn)
   protocol               = var.subscribers[each.key].protocol
   endpoint               = var.subscribers[each.key].endpoint
   endpoint_auto_confirms = var.subscribers[each.key].endpoint_auto_confirms
@@ -37,7 +37,7 @@ resource "aws_sns_topic_subscription" "this" {
   filter_policy_scope    = var.subscribers[each.key].filter_policy_scope
   raw_message_delivery   = var.subscribers[each.key].raw_message_delivery
   redrive_policy = var.sqs_dlq_enabled ? coalesce(var.redrive_policy, jsonencode({
-    deadLetterTargetArn = join("", aws_sqs_queue.dead_letter_queue.*.arn)
+    deadLetterTargetArn = join("", aws_sqs_queue.dead_letter_queue[*].arn)
     maxReceiveCount     = var.redrive_policy_max_receiver_count
   })) : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "subscribers" {
     # The protocol to use. The possible values for this are: sqs, sms, lambda, application. (http or https are partially supported, see below) (email is an option but is unsupported, see below).
     endpoint = string
     # The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
-    endpoint_auto_confirms = option(bool, false)
+    endpoint_auto_confirms = optional(bool, false)
     # Boolean indicating whether the end point is capable of auto confirming subscription e.g., PagerDuty (default is false)
     filter_policy = optional(string, null)
     # The filter policy JSON that is assigned to the subscription. For more information, see Amazon SNS Filter Policies.

--- a/variables.tf
+++ b/variables.tf
@@ -4,9 +4,13 @@ variable "subscribers" {
     # The protocol to use. The possible values for this are: sqs, sms, lambda, application. (http or https are partially supported, see below) (email is an option but is unsupported, see below).
     endpoint = string
     # The endpoint to send data to, the contents will vary with the protocol. (see below for more information)
-    endpoint_auto_confirms = bool
+    endpoint_auto_confirms = option(bool, false)
     # Boolean indicating whether the end point is capable of auto confirming subscription e.g., PagerDuty (default is false)
-    raw_message_delivery = bool
+    filter_policy = optional(string, null)
+    # The filter policy JSON that is assigned to the subscription. For more information, see Amazon SNS Filter Policies.
+    filter_policy_scope = optional(string, "MessageAttributes")
+    # The filter policy scope that is assigned to the subscription. Whether the `filter_policy` applies to `MessageAttributes` (default) or `MessageBody`
+    raw_message_delivery = optional(bool, false)
     # Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false)
   }))
   description = "Required configuration for subscibres to SNS topic."

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what
* Added filter_policy and filter_policy_scope functionality to subscribers
* Made some properties of `subscribers` variable optional with defaults values
* Bumped terraform version to `>= 1.3.0`

## why
* It will be great to have this functionality as feature request already [there](https://github.com/cloudposse/terraform-aws-sns-topic/issues/46).

## references
* https://github.com/cloudposse/terraform-aws-sns-topic/issues/46