### PR TITLE
fix(filter_policy_scope): changed default to null, added tests

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,3 +13,24 @@ module "sns" {
 
   context = module.this.context
 }
+
+resource "aws_sqs_queue" "sqs" {
+  name = "test-sqs"
+  fifo_queue = false
+}
+
+module "sns_with_subscriber" {
+  source = "../../"
+
+  allowed_aws_services_for_sns_published = var.allowed_aws_services_for_sns_published
+
+  subscribers = {
+    "sqs" = {
+      protocol = "sqs"
+      endpoint = aws_sqs_queue.sqs.arn
+      raw_message_delivery = true
+    }
+  }
+  context = module.this.context
+  attributes = ["sqs", "subscriber"]
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,7 +15,7 @@ module "sns" {
 }
 
 resource "aws_sqs_queue" "sqs" {
-  name = "test-sqs"
+  name       = "test-sqs"
   fifo_queue = false
 }
 
@@ -26,11 +26,11 @@ module "sns_with_subscriber" {
 
   subscribers = {
     "sqs" = {
-      protocol = "sqs"
-      endpoint = aws_sqs_queue.sqs.arn
+      protocol             = "sqs"
+      endpoint             = aws_sqs_queue.sqs.arn
       raw_message_delivery = true
     }
   }
-  context = module.this.context
+  context    = module.this.context
   attributes = ["sqs", "subscriber"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,8 +8,8 @@ variable "subscribers" {
     # Boolean indicating whether the end point is capable of auto confirming subscription e.g., PagerDuty (default is false)
     filter_policy = optional(string, null)
     # The filter policy JSON that is assigned to the subscription. For more information, see Amazon SNS Filter Policies.
-    filter_policy_scope = optional(string, "MessageAttributes")
-    # The filter policy scope that is assigned to the subscription. Whether the `filter_policy` applies to `MessageAttributes` (default) or `MessageBody`
+    filter_policy_scope = optional(string, null)
+    # The filter policy scope that is assigned to the subscription. Whether the `filter_policy` applies to `MessageAttributes` or `MessageBody`. Default is null.
     raw_message_delivery = optional(bool, false)
     # Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property) (default is false)
   }))


### PR DESCRIPTION
## what
 * Bug fix for default value of filter_policy_scope
 * Added test to avoid a similar bug in the future

## why
the default value(`MessageAttributes`) of `filter_policy_scope` cause error in the case when `filter_policy` is unset :
```
│ Error: filter_policy is required when filter_policy_scope is set
│ 
│   with module.sns_topic["my-topic"].aws_sns_topic_subscription.this["my-topic"],
│   on .terraform/modules/sns_topic/main.tf line 29, in resource "aws_sns_topic_subscription" "this":
│   29: resource "aws_sns_topic_subscription" "this" {
```